### PR TITLE
fix: prevent crash when reading email address from auth provider response fails

### DIFF
--- a/server/router/auth-router.go
+++ b/server/router/auth-router.go
@@ -476,7 +476,7 @@ func (router *AuthRouter) callback(w http.ResponseWriter, r *http.Request) {
 	claims, payload, err := router.getUserInfo(provider, r.FormValue("state"), r.FormValue("code"))
 	if err != nil {
 		log.Println(err)
-		SendTemporaryRedirect(w, router.getRedirectFailedUrl(payload.LoginType, provider))
+		SendTemporaryRedirect(w, router.getRedirectFailedUrl("ui", provider))
 		return
 	}
 	if !router.isValidEmailForOrg(provider, claims.Email) {


### PR DESCRIPTION
Fixes panic mentioned in #653 