### PR TITLE
fix: prevent clipping of search widget (Booking UI)

### DIFF
--- a/booking-ui/src/styles/Search.css
+++ b/booking-ui/src/styles/Search.css
@@ -78,7 +78,7 @@
     bottom: 0px;
     left: 0px;
     width: 100%;
-    height: 270px;
+    max-height: 350px;
     padding: 20px;
     padding-top: 0px;
     border-radius: 10px;


### PR DESCRIPTION
The search widget gets clipped by if an invalid date is selected (time in past or date too far in future): The 'show map' toggle is pushed beyond the screen edge.

Setting a max height instead of a fixed one should allow the widget to grow accordingly when a message is shown and prevent it to overlap too much with the area map

![Search widget clipped at bottom](https://github.com/user-attachments/assets/a6094bc7-c593-440d-8089-46d3439dff29)
![Search widget with max-width](https://github.com/user-attachments/assets/bd151d4e-e52b-4a18-9163-ee0b378c250d)