### PR TITLE
fix: align error message in search widget (Booking UI)

### DIFF
--- a/booking-ui/src/styles/Search.css
+++ b/booking-ui/src/styles/Search.css
@@ -184,6 +184,7 @@
     width: 100%;
     font-size: .875em;
     color: #dc3545;
+    margin-left: -2em;
 }
 
 .space-list.maximized {


### PR DESCRIPTION
Add a negative margin so the error message for invalid dates is aligned with the picker's fields.

![seatsurfing-invalid-date](https://github.com/user-attachments/assets/45378416-2699-4a2c-8176-415a522c9425)
![seatsurfing-invalid-date-aligned](https://github.com/user-attachments/assets/b1f1e7f2-4f0c-419b-8d14-2dddbb2e20bd)

An alternative would be to remove the [empty column div](https://github.com/seatsurfing/seatsurfing/blob/main/booking-ui/src/pages/search.tsx#L955) but I don't know that that was intended for