### PR TITLE
Add endpoint for esign room status queries 

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -69,6 +69,16 @@ func (a *App) InitializeRouter() {
 	routers["/space-attribute/"] = &SpaceAttributeRouter{}
 	routers["/confluence/"] = &ConfluenceRouter{}
 	routers["/uc/"] = &CheckUpdateRouter{}
+	// routers["/esign/"] = &EsignRouter{}
+
+	esignRouter := mux.NewRouter()
+	(&EsignRouter{}).SetupRoutes(esignRouter)
+
+	a.Router.PathPrefix("/esign/").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		esignRouter.ServeHTTP(w, r)
+	}))
+
+
 	for _, plg := range plugin.GetPlugins() {
 		for route, router := range (*plg).GetPublicRoutes() {
 			routers[route] = router

--- a/server/router/esign-router.go
+++ b/server/router/esign-router.go
@@ -1,0 +1,104 @@
+package router
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	. "github.com/seatsurfing/seatsurfing/server/repository"
+)
+
+type EsignRouter struct{}
+
+func (r *EsignRouter) SetupRoutes(s *mux.Router) {
+	s.HandleFunc("/esign/space/{id}/status", r.getSpaceStatus).Methods("GET")
+}
+
+func (r *EsignRouter) getSpaceStatus(w http.ResponseWriter, req *http.Request) {
+	// log.Println("EsignRouter: Received GET /space/{id}/status")
+
+	username, password, ok := req.BasicAuth()
+	// log.Printf("Auth attempt: ok=%v user=%s\n", ok, username)
+
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	users, err := GetUserRepository().GetUsersWithEmail(username)
+	if err != nil || len(users) == 0 {
+		log.Printf("Login failed: user not found for %s\n", username)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	user := users[0]
+
+	pwValue, err := user.HashedPassword.Value()
+	if err != nil {
+		log.Printf("Login failed: invalid stored password for %s\n", username)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	pwStr, ok := pwValue.(string)
+	if !ok || pwStr == "" {
+		log.Printf("Login failed: stored password not a string for %s\n", username)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if !GetUserRepository().CheckPassword(pwStr, password) {
+		log.Printf("Login failed: bad password for %s\n", username)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// log.Printf("Login successful for %s\n", username)
+
+	vars := mux.Vars(req)
+	spaceID := vars["id"]
+	// log.Printf("Returning status for spaceID: %s", spaceID)
+
+	space, err := GetSpaceRepository().GetOne(spaceID)
+	if err != nil {
+		http.Error(w, "Space not found", http.StatusNotFound)
+		return
+	}
+	location, err := GetLocationRepository().GetOne(space.LocationID)
+	if err != nil {
+		http.Error(w, "Location not found", http.StatusInternalServerError)
+		return
+	}
+
+	now := time.Now()
+	start := now.Add(-1 * time.Minute)
+	end := now.Add(1 * time.Minute)
+
+	list, err := GetSpaceRepository().GetAllInTime(location.ID, start, end)
+	if err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	userEmail := ""
+
+	for _, e := range list {
+		if e.Space.ID == space.ID {
+			for _, b := range e.Bookings {
+				enter, _ := GetLocationRepository().AttachTimezoneInformation(b.Enter, location)
+				leave, _ := GetLocationRepository().AttachTimezoneInformation(b.Leave, location)
+				if now.After(enter) && now.Before(leave) {
+					userEmail = b.UserEmail
+					break
+				}
+			}
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"userEmail": userEmail,
+	})
+}

--- a/server/router/unauthorized-routes.go
+++ b/server/router/unauthorized-routes.go
@@ -15,6 +15,8 @@ var unauthorizedRoutes = []string{
 	"/confluence",
 	"/booking/debugtimeissues/",
 	"/robots.txt",
+	"/esign/",
+	"/esign",
 }
 
 var unauthorizedRoutesOnce sync.Once


### PR DESCRIPTION
new endpoint under /esign/space/{id}/status, allowing basic-authenticated clients to query the current booking status of a specific space. This is intended for integration with external display devices (e.g., eSign project). 