### PR TITLE
fix: docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,5 @@ ADD version.txt /app/
 WORKDIR /app
 EXPOSE 8080
 USER 65532:65532
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD /app/healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD ["/app/healthcheck"]
 CMD ["./main"]


### PR DESCRIPTION
As there is no shell in distroless base image,
the healthcheck binary cannot be called via the
command shell form but must be called via the
command exec form.