### PR TITLE
fix(admin-ui): allow creating users when password login is disabled

### DIFF
--- a/ui/i18n/translations.de.json
+++ b/ui/i18n/translations.de.json
@@ -167,6 +167,7 @@
   "errorSave": "Fehler beim Speichern, bitte probiere es später noch einmal.",
   "errorUserRequired": "Bitte einen Benutzer auswählen.",
   "errorSubscriptionLimit": "Du hast die maximale Anzahl von Benutzern erreicht.",
+  "errorNoAuthProvider": "Passwort-Login ist auf dieser Instanz deaktiviert, ein neuer Benutzer muss daher einem Authentifizierungsanbieter zugeordnet werden. Bitte lege zuerst einen an.",
   "errorTooManyConcurrent": "Kapazitätsgrenze des gewählten Bereichs ist erreicht.",
   "errorTryAgain": "Etwas ist schief gegangen. Bitte probiere es später erneut.",
   "errorUnknown": "Unbekannter Fehler, bitte versuche es später erneut.",

--- a/ui/i18n/translations.en-GB.json
+++ b/ui/i18n/translations.en-GB.json
@@ -168,6 +168,7 @@
   "errorSave": "Error while saving, please try again later.",
   "errorUserRequired": "Please select a user.",
   "errorSubscriptionLimit": "You've reached the maximum number of users.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first.",
   "errorTooManyConcurrent": "Capacity limit reached in selected area.",
   "errorTryAgain": "Something went wrong. Please try again later.",
   "errorUnknown": "Unknown error, please try again later.",

--- a/ui/i18n/translations.en-US.json
+++ b/ui/i18n/translations.en-US.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.es.json
+++ b/ui/i18n/translations.es.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.et.json
+++ b/ui/i18n/translations.et.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.fi.json
+++ b/ui/i18n/translations.fi.json
@@ -564,5 +564,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.fr.json
+++ b/ui/i18n/translations.fr.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.he.json
+++ b/ui/i18n/translations.he.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.hu.json
+++ b/ui/i18n/translations.hu.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.it.json
+++ b/ui/i18n/translations.it.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.nl.json
+++ b/ui/i18n/translations.nl.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.pl.json
+++ b/ui/i18n/translations.pl.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.pt.json
+++ b/ui/i18n/translations.pt.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.ro.json
+++ b/ui/i18n/translations.ro.json
@@ -566,5 +566,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/i18n/translations.zh-TW.json
+++ b/ui/i18n/translations.zh-TW.json
@@ -564,5 +564,6 @@
   "primary": "Primary",
   "makePrimary": "Make primary",
   "makePrimaryVerifyTooltip": "The domain must be verified before it can be made primary.",
-  "removeDomainLastTooltip": "The last domain cannot be removed."
+  "removeDomainLastTooltip": "The last domain cannot be removed.",
+  "errorNoAuthProvider": "Password login is disabled on this instance, so a new user has to be assigned to an authentication provider. Please configure one first."
 }

--- a/ui/src/pages/admin/users/[id].tsx
+++ b/ui/src/pages/admin/users/[id].tsx
@@ -34,6 +34,15 @@ import Validation from "@/util/Validation";
 import Formatting from "@/util/Formatting";
 import RendererUtils from "@/util/RendererUtils";
 import ConfirmModal from "@/components/ConfirmModal";
+import {
+  defaultAuthMethodForNewUser,
+  isAuthMethodGroupHidden,
+  isAuthProviderGroupHidden,
+  isAuthProviderRequired,
+  isPasswordGroupHidden,
+  isPasswordRequired,
+  UserFormRuleInput,
+} from "@/util/UserFormRules";
 
 type PendingConfirmAction =
   "delete" | "resetPasskeys" | "resetTotp" | "revokeApiToken";
@@ -169,6 +178,21 @@ class EditUser extends React.Component<Props, State> {
           hasPasskeys: user.hasPasskeys,
           apiTokenConfigured,
           lastActivity: user.lastActivity,
+        });
+      } else {
+        // New user: password login may be disabled instance-wide, in which case
+        // the user can only be bound to an auth provider.
+        const authMethod = defaultAuthMethodForNewUser({
+          disablePasswordLogin: RuntimeConfig.INFOS.disablePasswordLogin,
+          hasAuthProviders: this.authProviders.length > 0,
+        });
+        this.setState({
+          authMethod,
+          authProviderId:
+            authMethod === User.AuthMethodProvider &&
+            this.authProviders.length === 1
+              ? this.authProviders[0].id
+              : "",
         });
       }
       this.setState({
@@ -383,6 +407,13 @@ class EditUser extends React.Component<Props, State> {
         </>
       );
     }
+    const formRules: UserFormRuleInput = {
+      hasUserId: !!this.entity.id,
+      isServiceAccount: this.isServiceAccount(this.state.role),
+      authMethod: this.state.authMethod,
+      changePassword: this.state.changePassword,
+      disablePasswordLogin: RuntimeConfig.INFOS.disablePasswordLogin,
+    };
     const isOwnUser = RuntimeConfig.INFOS.userId === this.entity.id;
     let roleSelect = <></>;
     if (!isOwnUser && this.adminUserRole >= this.state.role) {
@@ -544,13 +575,7 @@ class EditUser extends React.Component<Props, State> {
           </Form.Group>
 
           {/* Auth method selection for non-service accounts */}
-          <Form.Group
-            as={Row}
-            hidden={
-              this.isServiceAccount(this.state.role) ||
-              RuntimeConfig.INFOS.disablePasswordLogin
-            }
-          >
+          <Form.Group as={Row} hidden={isAuthMethodGroupHidden(formRules)}>
             <Form.Label htmlFor="auth-method-password" column sm="2">
               {this.props.t("authMethod")}
             </Form.Label>
@@ -591,14 +616,7 @@ class EditUser extends React.Component<Props, State> {
           </Form.Group>
 
           {/* Auth provider selection */}
-          <Form.Group
-            as={Row}
-            hidden={
-              this.isServiceAccount(this.state.role) ||
-              this.state.authMethod !== User.AuthMethodProvider ||
-              RuntimeConfig.INFOS.disablePasswordLogin
-            }
-          >
+          <Form.Group as={Row} hidden={isAuthProviderGroupHidden(formRules)}>
             <Form.Label htmlFor="authProvider" column sm="2">
               {this.props.t("chooseAuthProvider")}
             </Form.Label>
@@ -609,7 +627,7 @@ class EditUser extends React.Component<Props, State> {
                 onChange={(e: any) =>
                   this.setState({ authProviderId: e.target.value })
                 }
-                required={this.state.authMethod === User.AuthMethodProvider}
+                required={isAuthProviderRequired(formRules)}
               >
                 <option value="">{this.props.t("pleaseSelect")}</option>
                 {this.authProviders.map((provider) => (
@@ -667,15 +685,7 @@ class EditUser extends React.Component<Props, State> {
           </Form.Group>
 
           {/* Password field */}
-          <Form.Group
-            as={Row}
-            hidden={
-              (RuntimeConfig.INFOS.disablePasswordLogin &&
-                !this.isServiceAccount(this.state.role)) ||
-              (!this.isServiceAccount(this.state.role) &&
-                this.state.authMethod !== User.AuthMethodPassword)
-            }
-          >
+          <Form.Group as={Row} hidden={isPasswordGroupHidden(formRules)}>
             <Form.Label htmlFor="password" column sm="2">
               {this.props.t("password")}
             </Form.Label>
@@ -690,16 +700,7 @@ class EditUser extends React.Component<Props, State> {
                   onChange={(e: any) =>
                     this.setState({ password: e.target.value })
                   }
-                  required={
-                    !!(
-                      this.isServiceAccount(this.state.role) ||
-                      (!this.entity.id &&
-                        this.state.authMethod === User.AuthMethodPassword) ||
-                      (this.entity.id &&
-                        this.state.changePassword &&
-                        this.state.authMethod === User.AuthMethodPassword)
-                    )
-                  }
+                  required={isPasswordRequired(formRules)}
                   disabled={
                     (!this.isServiceAccount(this.state.role) &&
                       this.entity.id &&

--- a/ui/src/pages/admin/users/[id].tsx
+++ b/ui/src/pages/admin/users/[id].tsx
@@ -35,6 +35,7 @@ import Formatting from "@/util/Formatting";
 import RendererUtils from "@/util/RendererUtils";
 import ConfirmModal from "@/components/ConfirmModal";
 import {
+  canCreateUser,
   defaultAuthMethodForNewUser,
   isAuthMethodGroupHidden,
   isAuthProviderGroupHidden,
@@ -182,10 +183,9 @@ class EditUser extends React.Component<Props, State> {
       } else {
         // New user: password login may be disabled instance-wide, in which case
         // the user can only be bound to an auth provider.
-        const authMethod = defaultAuthMethodForNewUser({
-          disablePasswordLogin: RuntimeConfig.INFOS.disablePasswordLogin,
-          hasAuthProviders: this.authProviders.length > 0,
-        });
+        const authMethod = defaultAuthMethodForNewUser(
+          RuntimeConfig.INFOS.disablePasswordLogin,
+        );
         this.setState({
           authMethod,
           authProviderId:
@@ -212,8 +212,14 @@ class EditUser extends React.Component<Props, State> {
     this.entity.lastname = this.state.lastname;
     this.entity.role = this.state.role;
 
-    // Set authentication fields based on selected auth method
-    if (this.state.authMethod === User.AuthMethodInvitation) {
+    // Set authentication fields based on selected auth method. Service accounts
+    // always authenticate with their generated password, no matter which method
+    // the form defaulted to.
+    const isServiceAccount = this.isServiceAccount(this.state.role);
+    if (
+      !isServiceAccount &&
+      this.state.authMethod === User.AuthMethodInvitation
+    ) {
       // Only send invitation if email changed or explicitly requested
       const emailChanged = this.state.email !== this.state.originalEmail;
       const isNewUser = !this.entity.id;
@@ -221,12 +227,15 @@ class EditUser extends React.Component<Props, State> {
         isNewUser || emailChanged || this.state.resendInvitation;
       this.entity.password = "";
       this.entity.authProviderId = "";
-    } else if (this.state.authMethod === User.AuthMethodProvider) {
+    } else if (
+      !isServiceAccount &&
+      this.state.authMethod === User.AuthMethodProvider
+    ) {
       this.entity.sendInvitation = false;
       this.entity.password = "";
       this.entity.authProviderId = this.state.authProviderId;
     } else {
-      // password method
+      // password method (always used for service accounts)
       this.entity.sendInvitation = false;
       this.entity.authProviderId = "";
       if (this.state.changePassword || !this.entity.id) {
@@ -363,6 +372,20 @@ class EditUser extends React.Component<Props, State> {
       return (
         <FullLayout headline={this.props.t("editUser")} buttons={buttons}>
           <p>{this.props.t("errorSubscriptionLimit")}</p>
+        </FullLayout>
+      );
+    }
+
+    if (
+      !this.entity.id &&
+      !canCreateUser({
+        disablePasswordLogin: RuntimeConfig.INFOS.disablePasswordLogin,
+        hasAuthProviders: this.authProviders.length > 0,
+      })
+    ) {
+      return (
+        <FullLayout headline={this.props.t("editUser")} buttons={buttons}>
+          <p>{this.props.t("errorNoAuthProvider")}</p>
         </FullLayout>
       );
     }

--- a/ui/src/pages/admin/users/__tests__/addUserWithoutPasswordLogin.test.tsx
+++ b/ui/src/pages/admin/users/__tests__/addUserWithoutPasswordLogin.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+
+/**
+ * Regression test for creating a user on an instance started with
+ * DISABLE_PASSWORD_LOGIN=1 (password login off, Keycloak/OIDC only).
+ *
+ * The page used to keep the "password" auth method for new users, which left an
+ * empty *required* password input inside a *hidden* form group. Browsers abort
+ * such a submit and cannot show the validation message, so "Save" did nothing at
+ * all: no request, no error, no feedback.
+ */
+
+vi.mock("next-export-i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  useSelectedLanguage: () => ({ lang: "en" }),
+}));
+
+const { routerPush } = vi.hoisted(() => ({ routerPush: vi.fn() }));
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: { id: "add" },
+    push: routerPush,
+  }),
+  default: { push: routerPush },
+}));
+
+vi.mock("@/components/FullLayout", () => ({
+  default: ({ children, buttons }: any) =>
+    React.createElement("div", null, buttons, children),
+}));
+
+vi.mock("@/components/RuntimeConfig", () => ({
+  default: {
+    INFOS: {
+      userId: "admin-1",
+      disablePasswordLogin: true,
+      pluginWelcomeScreens: [],
+      pluginMenuItems: [],
+    },
+  },
+}));
+
+vi.mock("@/types/User", async () => {
+  const actual: any = await vi.importActual("@/types/User");
+  const User = actual.default;
+  User.getCount = vi.fn().mockResolvedValue(3);
+  User.getSelf = vi
+    .fn()
+    .mockResolvedValue({ id: "admin-1", role: User.UserRoleOrgAdmin });
+  User.get = vi.fn();
+  User.getApiTokenStatus = vi.fn().mockResolvedValue(false);
+  return { ...actual, default: User };
+});
+
+vi.mock("@/types/Settings", async () => {
+  const actual: any = await vi.importActual("@/types/Settings");
+  const OrgSettings = actual.default;
+  OrgSettings.getOne = vi.fn().mockResolvedValue("1"); // no user limit
+  return { ...actual, default: OrgSettings };
+});
+
+vi.mock("@/types/AuthProvider", async () => {
+  const actual: any = await vi.importActual("@/types/AuthProvider");
+  const AuthProvider = actual.default;
+  AuthProvider.list = vi
+    .fn()
+    .mockResolvedValue([{ id: "kc-1", name: "Keycloak" }]);
+  return { ...actual, default: AuthProvider };
+});
+
+import EditUser from "../[id]";
+
+const flush = async () => {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+};
+
+const renderPage = async () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(EditUser as any));
+  });
+  await flush();
+  return container;
+};
+
+const isVisible = (el: Element | null) => {
+  if (!el) return false;
+  let node: Element | null = el;
+  while (node) {
+    if (node.hasAttribute("hidden")) return false;
+    node = node.parentElement;
+  }
+  return true;
+};
+
+describe("add user with password login disabled", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    routerPush.mockClear();
+  });
+
+  it("does not leave a required password field inside a hidden group", async () => {
+    const container = await renderPage();
+    const password = container.querySelector<HTMLInputElement>("#password");
+    expect(password).not.toBeNull();
+    expect(isVisible(password)).toBe(false);
+    expect(password!.required).toBe(false);
+  });
+
+  it("shows the auth provider selection instead", async () => {
+    const container = await renderPage();
+    const provider =
+      container.querySelector<HTMLSelectElement>("#authProvider");
+    expect(isVisible(provider)).toBe(true);
+    expect(provider!.required).toBe(true);
+    // single provider is preselected, so the admin has nothing left to fill in
+    expect(provider!.value).toBe("kc-1");
+  });
+
+  it("can be submitted after filling in the visible fields", async () => {
+    const container = await renderPage();
+    const form = container.querySelector<HTMLFormElement>("#form");
+    const setValue = (selector: string, value: string) => {
+      const input = container.querySelector<HTMLInputElement>(selector)!;
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+    await act(async () => {
+      setValue("#email", "j.cermann@example.org");
+      setValue("#firstname", "Jessica");
+      setValue("#lastname", "Cermann");
+    });
+    await flush();
+    expect(form!.checkValidity()).toBe(true);
+  });
+});

--- a/ui/src/pages/admin/users/__tests__/addUserWithoutPasswordLogin.test.tsx
+++ b/ui/src/pages/admin/users/__tests__/addUserWithoutPasswordLogin.test.tsx
@@ -73,6 +73,7 @@ vi.mock("@/types/AuthProvider", async () => {
 });
 
 import EditUser from "../[id]";
+import User from "@/types/User";
 
 const flush = async () => {
   await act(async () => {
@@ -101,10 +102,62 @@ const isVisible = (el: Element | null) => {
   return true;
 };
 
+const submitForm = async (container: HTMLElement) => {
+  const form = container.querySelector<HTMLFormElement>("#form")!;
+  await act(async () => {
+    form.requestSubmit();
+  });
+  await flush();
+};
+
+const fillVisibleFields = async (container: HTMLElement) => {
+  const setValue = (selector: string, value: string) => {
+    const input = container.querySelector<HTMLInputElement>(selector)!;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  };
+  await act(async () => {
+    setValue("#email", "j.cermann@example.org");
+    setValue("#firstname", "Jessica");
+    setValue("#lastname", "Cermann");
+  });
+  await flush();
+};
+
+const selectRole = async (container: HTMLElement, role: number) => {
+  const select = container.querySelector<HTMLSelectElement>("#role")!;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLSelectElement.prototype,
+    "value",
+  )!.set!;
+  await act(async () => {
+    setter.call(select, String(role));
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await flush();
+};
+
 describe("add user with password login disabled", () => {
+  let saved: any = null;
+
   beforeEach(() => {
     document.body.innerHTML = "";
     routerPush.mockClear();
+    saved = null;
+    vi.spyOn(User.prototype, "save").mockImplementation(function (this: any) {
+      saved = {
+        password: this.password,
+        authProviderId: this.authProviderId,
+        sendInvitation: this.sendInvitation,
+        role: this.role,
+      };
+      this.id = "new-user-1";
+      return Promise.resolve(this);
+    });
   });
 
   it("does not leave a required password field inside a hidden group", async () => {
@@ -127,22 +180,38 @@ describe("add user with password login disabled", () => {
 
   it("can be submitted after filling in the visible fields", async () => {
     const container = await renderPage();
-    const form = container.querySelector<HTMLFormElement>("#form");
-    const setValue = (selector: string, value: string) => {
-      const input = container.querySelector<HTMLInputElement>(selector)!;
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )!.set!;
-      setter.call(input, value);
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-    };
-    await act(async () => {
-      setValue("#email", "j.cermann@example.org");
-      setValue("#firstname", "Jessica");
-      setValue("#lastname", "Cermann");
-    });
-    await flush();
-    expect(form!.checkValidity()).toBe(true);
+    await fillVisibleFields(container);
+    expect(
+      container.querySelector<HTMLFormElement>("#form")!.checkValidity(),
+    ).toBe(true);
+    await submitForm(container);
+    expect(saved).not.toBeNull();
+    expect(saved.authProviderId).toBe("kc-1");
+    expect(saved.password).toBe("");
+    expect(saved.sendInvitation).toBe(false);
+  });
+
+  it("refuses to create a user when no auth provider is configured", async () => {
+    const AuthProvider = (await import("@/types/AuthProvider")).default as any;
+    AuthProvider.list.mockResolvedValueOnce([]);
+    const container = await renderPage();
+    expect(container.querySelector("#form")).toBeNull();
+    expect(container.textContent).toContain("errorNoAuthProvider");
+  });
+
+  it("still creates service accounts with a password", async () => {
+    // Service accounts authenticate with a generated password even though the
+    // form defaults to the auth provider method on this kind of instance.
+    const container = await renderPage();
+    await fillVisibleFields(container);
+    await selectRole(container, User.UserRoleServiceAccountRW);
+    expect(
+      container.querySelector<HTMLFormElement>("#form")!.checkValidity(),
+    ).toBe(true);
+    await submitForm(container);
+    expect(saved).not.toBeNull();
+    expect(saved.role).toBe(User.UserRoleServiceAccountRW);
+    expect(saved.authProviderId).toBe("");
+    expect(saved.password).not.toBe("");
   });
 });

--- a/ui/src/util/UserFormRules.test.ts
+++ b/ui/src/util/UserFormRules.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import User from "@/types/User";
 import {
+  canCreateUser,
   defaultAuthMethodForNewUser,
+  isAuthMethodGroupHidden,
   isAuthProviderGroupHidden,
   isAuthProviderRequired,
   isPasswordGroupHidden,
@@ -19,30 +21,51 @@ const base: UserFormRuleInput = {
 
 describe("defaultAuthMethodForNewUser", () => {
   it("uses password login when it is enabled", () => {
-    expect(
-      defaultAuthMethodForNewUser({
-        disablePasswordLogin: false,
-        hasAuthProviders: true,
-      }),
-    ).toBe(User.AuthMethodPassword);
+    expect(defaultAuthMethodForNewUser(false)).toBe(User.AuthMethodPassword);
   });
 
   it("uses the auth provider when password login is disabled", () => {
+    expect(defaultAuthMethodForNewUser(true)).toBe(User.AuthMethodProvider);
+  });
+});
+
+describe("canCreateUser", () => {
+  it("allows creating users while password login is available", () => {
     expect(
-      defaultAuthMethodForNewUser({
-        disablePasswordLogin: true,
-        hasAuthProviders: true,
-      }),
-    ).toBe(User.AuthMethodProvider);
+      canCreateUser({ disablePasswordLogin: false, hasAuthProviders: false }),
+    ).toBe(true);
   });
 
-  it("falls back to invitation when password login is disabled and no provider exists", () => {
+  it("allows creating users bound to an auth provider", () => {
     expect(
-      defaultAuthMethodForNewUser({
-        disablePasswordLogin: true,
-        hasAuthProviders: false,
-      }),
-    ).toBe(User.AuthMethodInvitation);
+      canCreateUser({ disablePasswordLogin: true, hasAuthProviders: true }),
+    ).toBe(true);
+  });
+
+  it("refuses when no auth method could ever work", () => {
+    // Invitation links are rejected by the server while password login is
+    // disabled, so such a user could never sign in.
+    expect(
+      canCreateUser({ disablePasswordLogin: true, hasAuthProviders: false }),
+    ).toBe(false);
+  });
+});
+
+describe("isAuthMethodGroupHidden", () => {
+  it("hides the method choice when password login is disabled", () => {
+    expect(
+      isAuthMethodGroupHidden({ ...base, disablePasswordLogin: true }),
+    ).toBe(true);
+  });
+
+  it("hides the method choice for service accounts", () => {
+    expect(isAuthMethodGroupHidden({ ...base, isServiceAccount: true })).toBe(
+      true,
+    );
+  });
+
+  it("shows the method choice otherwise", () => {
+    expect(isAuthMethodGroupHidden(base)).toBe(false);
   });
 });
 

--- a/ui/src/util/UserFormRules.test.ts
+++ b/ui/src/util/UserFormRules.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import User from "@/types/User";
+import {
+  defaultAuthMethodForNewUser,
+  isAuthProviderGroupHidden,
+  isAuthProviderRequired,
+  isPasswordGroupHidden,
+  isPasswordRequired,
+  UserFormRuleInput,
+} from "./UserFormRules";
+
+const base: UserFormRuleInput = {
+  hasUserId: false,
+  isServiceAccount: false,
+  authMethod: User.AuthMethodPassword,
+  changePassword: false,
+  disablePasswordLogin: false,
+};
+
+describe("defaultAuthMethodForNewUser", () => {
+  it("uses password login when it is enabled", () => {
+    expect(
+      defaultAuthMethodForNewUser({
+        disablePasswordLogin: false,
+        hasAuthProviders: true,
+      }),
+    ).toBe(User.AuthMethodPassword);
+  });
+
+  it("uses the auth provider when password login is disabled", () => {
+    expect(
+      defaultAuthMethodForNewUser({
+        disablePasswordLogin: true,
+        hasAuthProviders: true,
+      }),
+    ).toBe(User.AuthMethodProvider);
+  });
+
+  it("falls back to invitation when password login is disabled and no provider exists", () => {
+    expect(
+      defaultAuthMethodForNewUser({
+        disablePasswordLogin: true,
+        hasAuthProviders: false,
+      }),
+    ).toBe(User.AuthMethodInvitation);
+  });
+});
+
+describe("password field", () => {
+  it("is required for a new user with password auth", () => {
+    expect(isPasswordRequired(base)).toBe(true);
+    expect(isPasswordGroupHidden(base)).toBe(false);
+  });
+
+  it("is not required while hidden because password login is disabled", () => {
+    // Regression: a new user created on an instance with DISABLE_PASSWORD_LOGIN=1
+    // used to keep authMethod "password", leaving an empty required field inside a
+    // hidden group. The browser then blocked the submit without any visible error.
+    const s: UserFormRuleInput = {
+      ...base,
+      disablePasswordLogin: true,
+      authMethod: User.AuthMethodProvider,
+    };
+    expect(isPasswordGroupHidden(s)).toBe(true);
+    expect(isPasswordRequired(s)).toBe(false);
+  });
+});
+
+describe("auth provider select", () => {
+  it("is visible and required when the provider auth method is active", () => {
+    const s: UserFormRuleInput = {
+      ...base,
+      disablePasswordLogin: true,
+      authMethod: User.AuthMethodProvider,
+    };
+    expect(isAuthProviderGroupHidden(s)).toBe(false);
+    expect(isAuthProviderRequired(s)).toBe(true);
+  });
+
+  it("is hidden and not required for another auth method", () => {
+    const s: UserFormRuleInput = {
+      ...base,
+      authMethod: User.AuthMethodInvitation,
+    };
+    expect(isAuthProviderGroupHidden(s)).toBe(true);
+    expect(isAuthProviderRequired(s)).toBe(false);
+  });
+});
+
+describe("invariant: a hidden control is never required", () => {
+  const bools = [false, true];
+  const methods = [
+    User.AuthMethodPassword,
+    User.AuthMethodProvider,
+    User.AuthMethodInvitation,
+  ];
+  it("holds for every combination of form state", () => {
+    for (const hasUserId of bools)
+      for (const isServiceAccount of bools)
+        for (const changePassword of bools)
+          for (const disablePasswordLogin of bools)
+            for (const authMethod of methods) {
+              const s: UserFormRuleInput = {
+                hasUserId,
+                isServiceAccount,
+                authMethod,
+                changePassword,
+                disablePasswordLogin,
+              };
+              const label = JSON.stringify(s);
+              if (isPasswordGroupHidden(s)) {
+                expect(isPasswordRequired(s), `password ${label}`).toBe(false);
+              }
+              if (isAuthProviderGroupHidden(s)) {
+                expect(isAuthProviderRequired(s), `provider ${label}`).toBe(
+                  false,
+                );
+              }
+            }
+  });
+});

--- a/ui/src/util/UserFormRules.ts
+++ b/ui/src/util/UserFormRules.ts
@@ -21,18 +21,26 @@ export interface UserFormRuleInput {
 
 /**
  * Auth method a newly created user starts with. With password login disabled
- * instance-wide, a new user can only authenticate through an auth provider.
+ * instance-wide, an auth provider is the only method that can work: invitation
+ * links are rejected by the server in that case.
  */
-export function defaultAuthMethodForNewUser(opts: {
+export function defaultAuthMethodForNewUser(
+  disablePasswordLogin: boolean,
+): string {
+  return disablePasswordLogin
+    ? User.AuthMethodProvider
+    : User.AuthMethodPassword;
+}
+
+/**
+ * With password login disabled and no auth provider configured, there is no way
+ * for a new user to ever sign in, so the form must not pretend otherwise.
+ */
+export function canCreateUser(opts: {
   disablePasswordLogin: boolean;
   hasAuthProviders: boolean;
-}): string {
-  if (!opts.disablePasswordLogin) {
-    return User.AuthMethodPassword;
-  }
-  return opts.hasAuthProviders
-    ? User.AuthMethodProvider
-    : User.AuthMethodInvitation;
+}): boolean {
+  return !opts.disablePasswordLogin || opts.hasAuthProviders;
 }
 
 export function isAuthMethodGroupHidden(s: UserFormRuleInput): boolean {

--- a/ui/src/util/UserFormRules.ts
+++ b/ui/src/util/UserFormRules.ts
@@ -1,0 +1,68 @@
+import User from "@/types/User";
+
+/**
+ * Visibility and validation rules for the "Edit User" admin form.
+ *
+ * These live outside the component so the relationship between a field's
+ * visibility and its "required" flag can be tested directly. A required form
+ * control inside a hidden group makes the browser abort the submit without
+ * being able to show its validation message, which leaves the user with a
+ * form that silently does nothing.
+ */
+export interface UserFormRuleInput {
+  /** false while creating a new user */
+  hasUserId: boolean;
+  isServiceAccount: boolean;
+  /** one of User.AuthMethod* */
+  authMethod: string;
+  changePassword: boolean;
+  disablePasswordLogin: boolean;
+}
+
+/**
+ * Auth method a newly created user starts with. With password login disabled
+ * instance-wide, a new user can only authenticate through an auth provider.
+ */
+export function defaultAuthMethodForNewUser(opts: {
+  disablePasswordLogin: boolean;
+  hasAuthProviders: boolean;
+}): string {
+  if (!opts.disablePasswordLogin) {
+    return User.AuthMethodPassword;
+  }
+  return opts.hasAuthProviders
+    ? User.AuthMethodProvider
+    : User.AuthMethodInvitation;
+}
+
+export function isAuthMethodGroupHidden(s: UserFormRuleInput): boolean {
+  return s.isServiceAccount || s.disablePasswordLogin;
+}
+
+export function isAuthProviderGroupHidden(s: UserFormRuleInput): boolean {
+  return s.isServiceAccount || s.authMethod !== User.AuthMethodProvider;
+}
+
+export function isAuthProviderRequired(s: UserFormRuleInput): boolean {
+  return !isAuthProviderGroupHidden(s);
+}
+
+export function isPasswordGroupHidden(s: UserFormRuleInput): boolean {
+  if (s.isServiceAccount) {
+    return false;
+  }
+  return s.disablePasswordLogin || s.authMethod !== User.AuthMethodPassword;
+}
+
+export function isPasswordRequired(s: UserFormRuleInput): boolean {
+  if (isPasswordGroupHidden(s)) {
+    return false;
+  }
+  if (s.isServiceAccount) {
+    return true;
+  }
+  if (!s.hasUserId) {
+    return s.authMethod === User.AuthMethodPassword;
+  }
+  return s.changePassword && s.authMethod === User.AuthMethodPassword;
+}


### PR DESCRIPTION
Fixes #2560.

## Problem

On an instance started with `DISABLE_PASSWORD_LOGIN=1`, creating a user in the admin UI did nothing: no request, no error, no feedback. A new user kept the constructor default auth method `password`, so the password input stayed `required` while its form group was hidden. Browsers abort such a submit and cannot show a validation message on a control they cannot focus, so `onSubmit` never ran and the page's own error handling never saw anything.

## Change

- New users default to the auth provider method when password login is disabled.
- The auth provider select stays visible when it is the active method. Without this the fix would only move the silent block to that control.
- Visibility and `required` rules move to `ui/src/util/UserFormRules.ts`, so a hidden control can never be required.
- Service accounts keep their generated password regardless of the defaulted auth method.
- With password login disabled and no auth provider configured, creating a user is refused with a hint instead of sending an invitation mail whose link the server rejects (`auth-router.go:392`).

Side effect worth naming: on such instances the provider select is now visible for existing provider-bound users too.

## Verification

`npm run test` (130 pass) and `tsc --noEmit` clean. The new page test fails on `main` and passes here. I could not run the Playwright e2e suite: no container runtime on this machine, so no screenshots either.
